### PR TITLE
css: remove hover transitions and remove header padding

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -420,7 +420,7 @@ input[type="color"] {
 
 /* Feed Header */
 .freshvibes-container-header {
-	padding: 8px 12px;
+	padding: 2px 12px;
 	background-color: var(--header-bg-color, var(--freshvibes-background-dark));
 	border-bottom: 1px solid var(--freshvibes-border-color);
 	cursor: grab;


### PR DESCRIPTION
Perhaps a personal take, but I find the small hover transitions for entries in a feed does not really come together well and makes the UI feel unpolished.

Consider pulling in one or more of these changes. Also fine if you don't want any of the changes. Will continue to maintain these locally for myself.

Changes:
- Removed transition of feed entries on hover
- Removed transition of entry actions. They just appear now.
- Remove hover transition for tabs
- Reduce the padding for container headers from 8px to 2px vertically. See the difference below. I think the padding is currently too large, especially when font is extra-small.
![image](https://github.com/user-attachments/assets/c99ecb78-0aad-4667-b279-215988916fb7)
vs
![image](https://github.com/user-attachments/assets/6368eedd-8e64-4f27-b53d-452c3679ab40)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified visual effects by removing certain hover animations and transitions.
  * Reduced padding in some header elements for a more compact appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->