### PR TITLE
Snippet on hover

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -754,7 +754,7 @@ function initializeDashboard(freshvibesView, urls, settings, csrfToken) {
 		let entryHTML = '';
 		if (feed.currentDisplayMode === 'tiny') {
 			entryHTML = `
-				<a class="entry-link" href="${entry.link}" target="_blank" rel="noopener noreferrer" data-entry-id="${entry.id}" data-feed-id="${feed.id}">
+				<a class="entry-link" href="${entry.link}" target="_blank" rel="noopener noreferrer" data-entry-id="${entry.id}" data-feed-id="${feed.id}" title="${entry.detailedSnippet}">
 					<div class="entry-main">
 						${favoriteIndicatorHTML}
 						<span class="entry-title">${entry.title || '(No title)'}</span>


### PR DESCRIPTION
I think Netvibes had that?? I found myself trying to do it from muscle memory on Freshvibes.

A longer snippet in “title” appearing on hover on each entry item, handy to decide whether or not to click on something you’re not sure you want to read.

Not sure the code works, I just thought I might as well try! :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooltips displaying detailed snippets when hovering over entries in the tiny display mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->